### PR TITLE
pwm and spi bugs

### DIFF
--- a/firmware/L9958.hpp
+++ b/firmware/L9958.hpp
@@ -51,7 +51,7 @@ void setup() {
 }
 
 void update() {
-    SPI.beginTransaction(SPISettings(14000000, LSBFIRST, SPI_MODE1));
+    SPI.beginTransaction(SPISettings(1000000, LSBFIRST, SPI_MODE1));
     digitalWrite(L9958_CS, LOW);
     memset(dataOut, 0, sizeof(dataOut));
     for (int i = 0; i < 2; i++)

--- a/firmware/controls_bluepad32.hpp
+++ b/firmware/controls_bluepad32.hpp
@@ -32,7 +32,7 @@ void read_controls() {
     if (!connected()) return;
     if (!xbox->hasData()) return;
     controls.throttle = xbox->throttle() - xbox->brake();
-    controls.steering = abs(controls.throttle) * xbox->axisX();
+    controls.steering = xbox->axisX();
     static int w = 0;
     static int p = 0;
     if (xbox->r1()) p = 1;

--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -33,7 +33,7 @@ void setup() {
     pinMode(RIGHT_PWM, OUTPUT);
     pinMode(LEFT_DIR, OUTPUT);
     pinMode(RIGHT_DIR, OUTPUT);
-    analogWriteResolution(1024);
+    analogWriteResolution(9);
     Serial.println("L9958 init");
     controls_setup();
     Serial.println("controls init");


### PR DESCRIPTION
fix 2 bugs:

* spi clock frequency was set to 14MHz due to copypasta but per datasheet max is 5Mhz. lowered it to 1Mhz to be safe.
* correctly set pwm resolution to 9 bit (I was requesting 1024 bit previously wtf??)