### PR TITLE
stupid wrong units

### DIFF
--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -77,5 +77,5 @@ void loop() {
     analogWrite(LEFT_PWM, abs(leftPower));
     digitalWrite(RIGHT_DIR, rightPower > 0);
     analogWrite(RIGHT_PWM, abs(rightPower));
-    esc.write(controls.weapon);
+    esc.writeMicroseconds(controls.weapon);
 }


### PR DESCRIPTION
i was using `.write()` which expects 0-180 but was passing the value for writeMicroseconds which is 1000-2000

stupid me for not catching it

stupid arduino for not allowing typed values on this kind of thing\n\n